### PR TITLE
Remove encouragement from signature help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ local.properties
 .settings/
 .loadpath
 
+# Roslyn generated folders
+*.sln.ide/
+
 # External tool builders
 .externalToolBuilders/
 

--- a/EncouragePackage/EncourageIntellisenseController.cs
+++ b/EncouragePackage/EncourageIntellisenseController.cs
@@ -29,7 +29,9 @@ namespace Haack.Encourage
             var triggerPoint = point.Snapshot.CreateTrackingPoint(point.Position, PointTrackingMode.Positive);
             if (!provider.SignatureHelpBroker.IsSignatureHelpActive(textView))
             {
+                textView.Properties.AddProperty(EncourageSignatureHelpSource.SessionKey, null);
                 session = provider.SignatureHelpBroker.TriggerSignatureHelp(textView, triggerPoint, true);
+                textView.Properties.RemoveProperty(EncourageSignatureHelpSource.SessionKey);
             }
         }
 

--- a/EncouragePackage/EncourageSignatureHelpSource.cs
+++ b/EncouragePackage/EncourageSignatureHelpSource.cs
@@ -56,6 +56,13 @@ namespace Haack.Encourage
             }
         }
 
+        /// <summary>
+        /// This object needs to be added as a key to the property bag of an ITextView where
+        /// encouragement should be applied.  This prevents encouragement from being 
+        /// introduced in places like signature overload.
+        /// </summary>
+        internal static readonly object SessionKey = new object();
+
         readonly ITextBuffer subjectBuffer;
         readonly IEncouragements encouragements;
 
@@ -78,6 +85,11 @@ namespace Haack.Encourage
 
         public void AugmentSignatureHelpSession(ISignatureHelpSession session, IList<ISignature> signatures)
         {
+            if (!session.TextView.Properties.ContainsProperty(SessionKey))
+            {
+                return;
+            }
+
             // Map the trigger point down to our buffer.
             var subjectTriggerPoint = session.GetTriggerPoint(subjectBuffer.CurrentSnapshot);
             if (!subjectTriggerPoint.HasValue)


### PR DESCRIPTION
This change stops the encouragement extension from displaying in
signature help documentation.

fixes #6
