### PR TITLE
Makes the project compatible with 2012

### DIFF
--- a/EncouragePackage/EncouragePackage.csproj
+++ b/EncouragePackage/EncouragePackage.csproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility" />
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />
     <Reference Include="Microsoft.VisualStudio.Text.UI" />


### PR DESCRIPTION
I just changed all the refs to version "12.0" to "11.0".  Seems like it works fine in 2012 now, but I don't have 2013 to test with to make sure it still works there.

If this isn't a good way to do this, is there a better way to manage extensions across different versions of VS?  A separate project for each version with the files linked in?  Just thinking out loud.

Thanks,
John Bubriski
