### PR TITLE
Clear the annotations before adding a new one

### DIFF
--- a/EncouragePackage/EncourageSignatureHelpSource.cs
+++ b/EncouragePackage/EncourageSignatureHelpSource.cs
@@ -104,6 +104,7 @@ namespace Haack.Encourage
                 1,
                 SpanTrackingMode.EdgeInclusive);
 
+            signatures.Clear();
             string encouragement = encouragements.GetRandomEncouragement();
             var signature = new Signature(applicableToSpan, encouragement, "", "");
             signatures.Add(signature);


### PR DESCRIPTION
I got this behaviour which is somewhat wrong:
![image](https://cloud.githubusercontent.com/assets/462013/3398197/eddd33b6-fd2b-11e3-81d7-a517f0842b90.png)

I _guess_ this change will fix the problem.
