### PR TITLE
Fixes encouragement at the end of the document

### DIFF
--- a/EncouragePackage/EncourageSignatureHelpSource.cs
+++ b/EncouragePackage/EncourageSignatureHelpSource.cs
@@ -101,7 +101,7 @@ namespace Haack.Encourage
             var querySpan = new SnapshotSpan(subjectTriggerPoint.Value, 0);
             var applicableToSpan = currentSnapshot.CreateTrackingSpan(
                 querySpan.Start.Position,
-                1,
+                0,
                 SpanTrackingMode.EdgeInclusive);
 
             string encouragement = encouragements.GetRandomEncouragement();


### PR DESCRIPTION
When the caret is at the very end of the document the trigger point
comes back as the end point of the document.  The equivalent of

```
new Snapshot(snapshot, snapshot.Length);
```

We then created a tracking span of trigger point + 1.  This creates a
point past the end of the buffer and hence caused an exception to be
raised.  The fix is to simply have a 0 length tracking span here.
