### PR TITLE
Encouragement displays only on dirty state change

### DIFF
--- a/EncouragePackage/EncourageIntellisenseControllerProvider.cs
+++ b/EncouragePackage/EncourageIntellisenseControllerProvider.cs
@@ -18,12 +18,17 @@ namespace Haack.Encourage
         internal ISignatureHelpBroker SignatureHelpBroker { get; set; }
 
         [Import]
-        internal SVsServiceProvider ServiceProvider = null;
+        internal ITextDocumentFactoryService TextDocumentFactoryService = null;
 
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers)
         {
-            var dte = (DTE)ServiceProvider.GetService(typeof(DTE));
-            return new EncourageIntellisenseController(textView, dte, this);
+            ITextDocument textDocument;
+            if (!TextDocumentFactoryService.TryGetTextDocument(textView.TextBuffer, out textDocument))
+            {
+                return null;
+            }
+
+            return new EncourageIntellisenseController(textView, textDocument, this);
         }
     }
 }


### PR DESCRIPTION
Previously encouragement would display when
1. A Save operation occurred independent of whether or not the document
   was dirty
2. A Save All operation occurred and document was dirty

This unifies the behavior to display encouragement only when the file is
actually saved (the dirty state changes).
closes #13
