### PR TITLE
Remove javascript signatures from encouragement

### DIFF
--- a/EncouragePackage/EncourageSignatureHelpSource.cs
+++ b/EncouragePackage/EncourageSignatureHelpSource.cs
@@ -90,6 +90,13 @@ namespace Haack.Encourage
                 return;
             }
 
+            // At the moment there is a bug in the javascript provider which causes it to 
+            // repeatedly insert the same Signature values into an ISignatureHelpSession
+            // instance.  There is no way, other than reflection, for us to prevent this
+            // from happening.  Instead we just ensure that our provider runs after 
+            // Javascript and then remove the values they add here 
+            signatures.Clear();
+
             // Map the trigger point down to our buffer.
             var subjectTriggerPoint = session.GetTriggerPoint(subjectBuffer.CurrentSnapshot);
             if (!subjectTriggerPoint.HasValue)

--- a/EncouragePackage/EncourageSignatureHelpSourceProvider.cs
+++ b/EncouragePackage/EncourageSignatureHelpSourceProvider.cs
@@ -9,6 +9,7 @@ namespace Haack.Encourage
     [Export(typeof(ISignatureHelpSourceProvider))]
     [Name("ToolTip SignatureHelp Source")]
     [Order(Before = "Default Signature Help Presenter")]
+    [Order(After = "JavaScript Signature Help source")]
     [ContentType("text")]
     internal class EncourageSignatureHelpSourceProvider : ISignatureHelpSourceProvider
     {


### PR DESCRIPTION
The Javascript IDE implementation has a bug where by it will insert its
signature help into any ISignatureHelpSession that is started.  This
includes the session that is started by the Enouragement extension.
This causes encouragement tips to be intermixed with javascript
signatures

Due to the implementation of the Javascript provider the only suitable
short term fix is to a) run after them and b) just remove their
signatures from our session.

This fixes #16

As a consequence it also fixes #1 as well.
