### PR TITLE
Remove Encouragement from Immediate Window

### DIFF
--- a/EncouragePackage/EncourageIntellisenseControllerProvider.cs
+++ b/EncouragePackage/EncourageIntellisenseControllerProvider.cs
@@ -28,6 +28,18 @@ namespace Haack.Encourage
                 return null;
             }
 
+            // In general having an ITextDocument is sufficient to determine if a given ITextView is 
+            // back by an actual document.  There are some windows though, like the Immediate Window, 
+            // which aren't documents that do still have a backing temporary file.  These files are
+            // uninteresting to Encourage because they are temporary files that exist as an
+            // implementation detail
+            //
+            // The easiest way to filter for real documents is to check for the Document role 
+            if (!textView.Roles.Contains(PredefinedTextViewRoles.Document))
+            {
+                return null;
+            }
+
             return new EncourageIntellisenseController(textView, textDocument, this);
         }
     }


### PR DESCRIPTION
Encouragement was using the presence of an ITextDocument as the
predicate for whether or not a given ITextView is eligible for
encouragement tips  Having an ITextDocument means a given ITextView is
backed by a physical file and saving such an item should be encouraged.

The problem is windows like the 'Immediate Window' are backed by
physical files (esp with Roslyn).  These files are implementation
details though and saving them has no benefit to the user.  In these
cases the save operation isn't even directly surfaced to the user.  It
happens as a consequence of a non-save like action (in the case of the
'Immediate Window', it happens on every key stroke).  This causes
Encouragement to be displayed at unexpected times

This change fixes this problem by changing the predicate slightly.  We
now check for ITextDocument (has ITextView has a physical backing file)
and the Document role (this ITextView is being displayed as a document).

closes #19
