### PR TITLE
Use document buffer

### DIFF
--- a/EncouragePackage/EncourageIntellisenseControllerProvider.cs
+++ b/EncouragePackage/EncourageIntellisenseControllerProvider.cs
@@ -23,7 +23,7 @@ namespace Haack.Encourage
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers)
         {
             ITextDocument textDocument;
-            if (!TextDocumentFactoryService.TryGetTextDocument(textView.TextBuffer, out textDocument))
+            if (!TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out textDocument))
             {
                 return null;
             }


### PR DESCRIPTION
An ITextView can have multiple ITextBuffer instances associated with it.
When looking for the main ITextDocument associated with an ITextView it
should always be done through the DocumentBuffer.  The previous code was
using ITextView::TextBuffer which is equivalent to the EditBuffer.

The reason this worked in standard files (like a .cs) is that the
EditBuffer and DocumentBuffer are the same value.  In razor files the
view is much more complex and the EditBuffer is actually a rather
complicated projection buffer (instance of IProjectionBuffer).  Hence it
had no associated document.

closes #21
