### PR TITLE
"Encouragement" typo in option page

### DIFF
--- a/EncouragePackage/Options/OptionsDialogPageControl.xaml
+++ b/EncouragePackage/Options/OptionsDialogPageControl.xaml
@@ -14,7 +14,7 @@
         <TextBlock
             Grid.Row="0"
             Padding="5"
-            Text="Enter each encourament on its own line" />
+            Text="Enter each encouragement on its own line" />
         <TextBox
             x:Name="encouragements"
             Grid.Row="1"


### PR DESCRIPTION
Seen in screenshot of haacked/Encourage#30

![testencouragelist](https://cloud.githubusercontent.com/assets/430293/3895871/d8ad1f7e-2251-11e4-8f46-a52628f9b7f7.png)
