### PR TITLE
Visual Studio 2015 RC support

### DIFF
--- a/EncouragePackage/source.extension.vsixmanifest
+++ b/EncouragePackage/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     <License>LICENSE.txt</License>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0, 12.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0, 14.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Extremely minor change. @jaredpar already did the majority of the work when he made the changes to support Visual Studio 2012, I'm only adding that I have tested on 2015 and it works fine.

I have tested that this extension works on a machine with Visual Studio 2013 and 2015 RC installed and on another machine with just 2015 RC installed to prove that it does not require assemblies that are added by 2012 or 2013.